### PR TITLE
Database, release & Deployer version cleanup.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: 7.3
           coverage: none
           tools: composer:v2, cs2pr
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,29 @@ Please choose a platform to view related documentation.
 * [Drupal](cms/drupal)
 * [WordPress](cms/wp)
 
+### Before/After Hooks
+Deployer supports running tasks before or after other defined tasks. Defining
+custom tasks to trigger before & after other defined tasks is trivial. Such
+functionality can be added to the end of `deploy.yaml`, as shown below:
+
+```yaml
+tasks:
+    foo:
+        script:
+            - "echo 'foo'"
+    bar:
+        script:
+            - "echo 'bar'"
+
+after:
+    deploy:symlink: foo
+
+before:
+    deploy:unlock: bar
+```
+
 ## References
-* <https://github.com/deployphp/deployer/blob/master/deploy.yaml>
-* <https://lorisleiva.com/deploy-your-laravel-app-from-scratch/install-and-configure-deployer>
-* <https://lorisleiva.com/deploy-your-laravel-app-from-scratch/create-your-own-deployer-recipes>
+* [Deployer 7 Documentation](https://deployer.org/docs/7.x/getting-started)
+* [Default Deployer 7 Configuration](https://github.com/deployphp/deployer/blob/master/deploy.yaml)
+* [Install and configure Deployer](https://lorisleiva.com/deploy-your-laravel-app-from-scratch/install-and-configure-deployer)
+* [Create Your Own Deployer Recipes](https://lorisleiva.com/deploy-your-laravel-app-from-scratch/create-your-own-deployer-recipes)

--- a/cms/drupal/8.yml
+++ b/cms/drupal/8.yml
@@ -1,17 +1,18 @@
 import:
     - "recipe/drupal8.php"
+    - "vendor/unleashedtech/deployer-recipes/db/backup/cleanup.yml"
+    - "vendor/unleashedtech/deployer-recipes/db/backup/download.php"
     - "vendor/unleashedtech/deployer-recipes/config.yml"
     - "vendor/unleashedtech/deployer-recipes/cms/drupal/cache/rebuild.yml"
     - "vendor/unleashedtech/deployer-recipes/cms/drupal/config/import.yml"
-    - "vendor/unleashedtech/deployer-recipes/db/backup/cleanup.yml"
     - "vendor/unleashedtech/deployer-recipes/cms/drupal/db/backup/create.php"
-    - "vendor/unleashedtech/deployer-recipes/db/backup/download.php"
     - "vendor/unleashedtech/deployer-recipes/cms/drupal/db/backup/import.php"
     - "vendor/unleashedtech/deployer-recipes/cms/drupal/db/pull.yml"
     - "vendor/unleashedtech/deployer-recipes/cms/drupal/db/update.yml"
     - "vendor/unleashedtech/deployer-recipes/cms/drupal/post/deploy.yml"
     - "vendor/unleashedtech/deployer-recipes/cms/drupal/pre/deploy.yml"
     - "vendor/unleashedtech/deployer-recipes/cms/drupal/pre/release.yml"
+    - "vendor/unleashedtech/deployer-recipes/cms/drupal/release/cleanup.php"
     - "vendor/unleashedtech/deployer-recipes/cms/drupal/themes/build.php"
     - "vendor/unleashedtech/deployer-recipes/cms/drupal/tools/login.yml"
 
@@ -37,5 +38,4 @@ tasks:
         - cms:drupal:pre:deploy
         - deploy:symlink
         - cms:drupal:post:deploy
-        - deploy:cleanup
         - deploy:unlock

--- a/cms/drupal/8.yml
+++ b/cms/drupal/8.yml
@@ -1,38 +1,41 @@
 import:
-  - "recipe/drupal8.php"
-  - "vendor/unleashedtech/deployer-recipes/config.yml"
-  - "vendor/unleashedtech/deployer-recipes/cms/drupal/cache/rebuild.yml"
-  - "vendor/unleashedtech/deployer-recipes/cms/drupal/config/import.yml"
-  - "vendor/unleashedtech/deployer-recipes/db/backup/cleanup.yml"
-  - "vendor/unleashedtech/deployer-recipes/cms/drupal/db/backup/create.php"
-  - "vendor/unleashedtech/deployer-recipes/db/backup/download.php"
-  - "vendor/unleashedtech/deployer-recipes/cms/drupal/db/backup/import.php"
-  - "vendor/unleashedtech/deployer-recipes/cms/drupal/db/pull.yml"
-  - "vendor/unleashedtech/deployer-recipes/cms/drupal/db/update.yml"
-  - "vendor/unleashedtech/deployer-recipes/cms/drupal/post/deploy.yml"
-  - "vendor/unleashedtech/deployer-recipes/cms/drupal/pre/deploy.yml"
-  - "vendor/unleashedtech/deployer-recipes/cms/drupal/pre/release.yml"
-  - "vendor/unleashedtech/deployer-recipes/cms/drupal/tools/login.yml"
+    - "recipe/drupal8.php"
+    - "vendor/unleashedtech/deployer-recipes/config.yml"
+    - "vendor/unleashedtech/deployer-recipes/cms/drupal/cache/rebuild.yml"
+    - "vendor/unleashedtech/deployer-recipes/cms/drupal/config/import.yml"
+    - "vendor/unleashedtech/deployer-recipes/db/backup/cleanup.yml"
+    - "vendor/unleashedtech/deployer-recipes/cms/drupal/db/backup/create.php"
+    - "vendor/unleashedtech/deployer-recipes/db/backup/download.php"
+    - "vendor/unleashedtech/deployer-recipes/cms/drupal/db/backup/import.php"
+    - "vendor/unleashedtech/deployer-recipes/cms/drupal/db/pull.yml"
+    - "vendor/unleashedtech/deployer-recipes/cms/drupal/db/update.yml"
+    - "vendor/unleashedtech/deployer-recipes/cms/drupal/post/deploy.yml"
+    - "vendor/unleashedtech/deployer-recipes/cms/drupal/pre/deploy.yml"
+    - "vendor/unleashedtech/deployer-recipes/cms/drupal/pre/release.yml"
+    - "vendor/unleashedtech/deployer-recipes/cms/drupal/themes/build.php"
+    - "vendor/unleashedtech/deployer-recipes/cms/drupal/tools/login.yml"
 
 config:
-  app_type: drupal
-  drush: '{{bin}}/drush'
-  drupal_site: default
-  shared_dirs:
-    - 'web/sites/{{drupal_site}}/files'
-  shared_files:
-    - 'web/sites/{{drupal_site}}/settings.php'
-    - 'web/sites/{{drupal_site}}/settings.local.php'
-    - 'web/sites/{{drupal_site}}/services.yml'
-  writable_dirs:
-    - 'web/sites/{{drupal_site}}/files'
+    app_type: drupal
+    drush: '{{bin}}/drush'
+    drupal_site: default
+    shared_dirs:
+        - 'web/sites/{{drupal_site}}/files'
+    shared_files:
+        - 'web/sites/{{drupal_site}}/settings.php'
+        - 'web/sites/{{drupal_site}}/settings.local.php'
+        - 'web/sites/{{drupal_site}}/services.yml'
+    themes:
+        - '{{app_path}}/themes/custom/{{namespace}}_theme'
+    writable_dirs:
+        - 'web/sites/{{drupal_site}}/files'
 
 tasks:
-  deploy:
-    - cms:drupal:pre:release
-    - deploy:prepare
-    - cms:drupal:pre:deploy
-    - deploy:symlink
-    - cms:drupal:post:deploy
-    - deploy:cleanup
-    - deploy:unlock
+    deploy:
+        - cms:drupal:pre:release
+        - deploy:prepare
+        - cms:drupal:pre:deploy
+        - deploy:symlink
+        - cms:drupal:post:deploy
+        - deploy:cleanup
+        - deploy:unlock

--- a/cms/drupal/8.yml
+++ b/cms/drupal/8.yml
@@ -34,4 +34,5 @@ tasks:
     - cms:drupal:pre:deploy
     - deploy:symlink
     - cms:drupal:post:deploy
+    - deploy:cleanup
     - deploy:unlock

--- a/cms/drupal/8.yml
+++ b/cms/drupal/8.yml
@@ -1,20 +1,20 @@
 import:
-    - "recipe/drupal8.php"
-    - "vendor/unleashedtech/deployer-recipes/db/backup/cleanup.yml"
-    - "vendor/unleashedtech/deployer-recipes/db/backup/download.php"
-    - "vendor/unleashedtech/deployer-recipes/config.yml"
-    - "vendor/unleashedtech/deployer-recipes/cms/drupal/cache/rebuild.yml"
-    - "vendor/unleashedtech/deployer-recipes/cms/drupal/config/import.yml"
-    - "vendor/unleashedtech/deployer-recipes/cms/drupal/db/backup/create.php"
-    - "vendor/unleashedtech/deployer-recipes/cms/drupal/db/backup/import.php"
-    - "vendor/unleashedtech/deployer-recipes/cms/drupal/db/pull.yml"
-    - "vendor/unleashedtech/deployer-recipes/cms/drupal/db/update.yml"
-    - "vendor/unleashedtech/deployer-recipes/cms/drupal/post/deploy.yml"
-    - "vendor/unleashedtech/deployer-recipes/cms/drupal/pre/deploy.yml"
-    - "vendor/unleashedtech/deployer-recipes/cms/drupal/pre/release.yml"
-    - "vendor/unleashedtech/deployer-recipes/cms/drupal/release/cleanup.php"
-    - "vendor/unleashedtech/deployer-recipes/cms/drupal/themes/build.php"
-    - "vendor/unleashedtech/deployer-recipes/cms/drupal/tools/login.yml"
+    - recipe/drupal8.php
+    - vendor/unleashedtech/deployer-recipes/db/backup/cleanup.yml
+    - vendor/unleashedtech/deployer-recipes/db/backup/download.php
+    - vendor/unleashedtech/deployer-recipes/config.yml
+    - vendor/unleashedtech/deployer-recipes/cms/drupal/cache/rebuild.yml
+    - vendor/unleashedtech/deployer-recipes/cms/drupal/config/import.yml
+    - vendor/unleashedtech/deployer-recipes/cms/drupal/db/backup/create.php
+    - vendor/unleashedtech/deployer-recipes/cms/drupal/db/backup/import.php
+    - vendor/unleashedtech/deployer-recipes/cms/drupal/db/pull.yml
+    - vendor/unleashedtech/deployer-recipes/cms/drupal/db/update.yml
+    - vendor/unleashedtech/deployer-recipes/cms/drupal/post/deploy.yml
+    - vendor/unleashedtech/deployer-recipes/cms/drupal/pre/deploy.yml
+    - vendor/unleashedtech/deployer-recipes/cms/drupal/pre/release.yml
+    - vendor/unleashedtech/deployer-recipes/cms/drupal/themes/build.php
+    - vendor/unleashedtech/deployer-recipes/cms/drupal/tools/login.yml
+    - vendor/unleashedtech/deployer-recipes/releases/cleanup.php
 
 config:
     app_type: drupal
@@ -38,4 +38,3 @@ tasks:
         - cms:drupal:pre:deploy
         - deploy:symlink
         - cms:drupal:post:deploy
-        - deploy:unlock

--- a/cms/drupal/9.yml
+++ b/cms/drupal/9.yml
@@ -1,2 +1,2 @@
 import:
-  - "vendor/unleashedtech/deployer-recipes/cms/drupal/8.yml"
+    - "vendor/unleashedtech/deployer-recipes/cms/drupal/8.yml"

--- a/cms/drupal/README.md
+++ b/cms/drupal/README.md
@@ -21,17 +21,28 @@ is also being overridden.
 
 ```yaml
 import:
-    - "vendor/unleashedtech/deployer-recipes/cms/drupal/5.yml"
+    - 'vendor/unleashedtech/deployer-recipes/cms/drupal/9.yml'
 
 config:
     namespace: foo
     repository_user: bar
-    repository_domain: 'repository1.example`
-    dev_domain: 'dev1.example`
-    staging_domain: 'staging1.example`
-    production_domain: 'production1.example`
+    repository_domain: 'repository1.example'
+    dev_domain: 'dev1.example'
+    staging_domain: 'staging1.example'
+    production_domain: 'production1.example'
     writable_dirs:
         - 'docroot/sites/{{default_site}}/files'
 ```
 
-Many defaults are provided. You will need to override a few of them.
+Many defaults are provided. You will need to override a few of them. Your configuration
+may be as simple as:
+
+```yaml
+import:
+    - 'vendor/unleashedtech/deployer-recipes/cms/drupal/9.yml'
+
+config:
+    namespace: foo
+    repository_domain: 'repository1.example'
+    staging_domain: 'staging1.example'
+```

--- a/cms/drupal/cache/rebuild.yml
+++ b/cms/drupal/cache/rebuild.yml
@@ -2,4 +2,4 @@ tasks:
   cms:drupal:cache:rebuild:
     desc: 'Rebuilds Drupal caches.'
     script:
-      - "{{drush}} rq && {{drush}} cr || echo 'Database not available'"
+      - "{{drush}} cr || echo 'Database not available'"

--- a/cms/drupal/config/import.yml
+++ b/cms/drupal/config/import.yml
@@ -2,4 +2,4 @@ tasks:
   cms:drupal:config:import:
     desc: 'Imports config into Drupal from code in the repo.'
     script:
-      - '{{drush}} rq && {{drush}} config:import -y || echo "Database not available"'
+      - '{{drush}} config:import -y || echo "Database not available"'

--- a/cms/drupal/db/backup/create.php
+++ b/cms/drupal/db/backup/create.php
@@ -33,6 +33,6 @@ task('cms:drupal:db:backup:create', static function (): void {
         //foreach ($aliases as $alias => $info) {}
 
         $filename = '{{namespace}}--' . $date . '.sql';
-        run('{{drush}} rq && {{drush}} sql:dump --gzip --result-file={{backups}}/' . $filename . "|| echo 'Database not available'", ['timeout' => null]);
+        run('{{drush}} sql:dump --gzip --result-file={{backups}}/' . $filename . "|| echo 'Database not available'", ['timeout' => null]);
     });
 })->desc('Create a database backup files.')->once();

--- a/cms/drupal/db/backup/create.php
+++ b/cms/drupal/db/backup/create.php
@@ -33,6 +33,6 @@ task('cms:drupal:db:backup:create', static function (): void {
         //foreach ($aliases as $alias => $info) {}
 
         $filename = '{{namespace}}--' . $date . '.sql';
-        run('{{drush}} rq && {{drush}} sql:dump --gzip --result-file={{backups}}' . $filename . "|| echo 'Database not available'", ['timeout' => null]);
+        run('{{drush}} rq && {{drush}} sql:dump --gzip --result-file={{backups}}/' . $filename . "|| echo 'Database not available'", ['timeout' => null]);
     });
 })->desc('Create a database backup files.')->once();

--- a/cms/drupal/db/update.yml
+++ b/cms/drupal/db/update.yml
@@ -2,4 +2,4 @@ tasks:
   cms:drupal:db:update:
     desc: 'Updates the Drupal DB based on Drupal install files.'
     script:
-      - '{{drush}} rq && {{drush}} updb -y || echo "Database not available"'
+      - '{{drush}} updb -y || echo "Database not available"'

--- a/cms/drupal/post/deploy.yml
+++ b/cms/drupal/post/deploy.yml
@@ -9,3 +9,4 @@ tasks:
     # TODO: move this into the cms:drupal:pre:deploy task
     - cms:drupal:config:import
     - db:backup:cleanup
+    - cms:drupal:release:cleanup

--- a/cms/drupal/post/deploy.yml
+++ b/cms/drupal/post/deploy.yml
@@ -9,4 +9,5 @@ tasks:
     # TODO: move this into the cms:drupal:pre:deploy task
     - cms:drupal:config:import
     - db:backup:cleanup
-    - cms:drupal:release:cleanup
+    - releases:cleanup
+    - deploy:unlock

--- a/cms/drupal/post/deploy.yml
+++ b/cms/drupal/post/deploy.yml
@@ -3,6 +3,8 @@ tasks:
     # TODO: move this into the cms:drupal:pre:deploy task
     - cms:drupal:db:update
     # TODO: move this into the cms:drupal:pre:deploy task
+    - cms:drupal:themes:build
+    # TODO: move this into the cms:drupal:pre:deploy task
     - cms:drupal:cache:rebuild
     # TODO: move this into the cms:drupal:pre:deploy task
     - cms:drupal:config:import

--- a/cms/drupal/release/cleanup.php
+++ b/cms/drupal/release/cleanup.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Cleans up old releases. Based on contrib deploy:cleanup task.
+ *
+ * @file
+ */
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+// Use sudo in deploy:cleanup task for rm command.
+set('cleanup_use_sudo', false);
+
+desc('Clean up old releases');
+task('cms:drupal:release:cleanup', static function (): void {
+    $releases = get('releases_list');
+    $keep     = get('keep_releases');
+    $sudo     = get('cleanup_use_sudo') ? 'sudo' : '';
+    $runOpts  = [];
+
+    if ($keep === -1) {
+        // Keep unlimited releases.
+        return;
+    }
+
+    while ($keep > 0) {
+        \array_shift($releases);
+        --$keep;
+    }
+
+    foreach ($releases as $release) {
+        run('chmod -R +w {{deploy_path}}/releases/' . $release);
+        run($sudo . ' rm -rf {{deploy_path}}/releases/' . $release, $runOpts);
+    }
+
+    run('cd {{deploy_path}} && if [ -e release ]; then rm release; fi', $runOpts);
+});

--- a/cms/drupal/themes/build.php
+++ b/cms/drupal/themes/build.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Builds Drupal theme(s).
+ *
+ * @file
+ */
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+task('cms:drupal:themes:build', static function (): void {
+    foreach (get('themes') as $theme) {
+        within($theme, static function (): void {
+            // @todo Detect theme package manager & task runner. Run commands based on that data.
+            run('npm install');
+            run('gulp build');
+        });
+    }
+});

--- a/cms/wp/5.yml
+++ b/cms/wp/5.yml
@@ -1,38 +1,36 @@
----
 import:
-  - recipe/common.php
-  - recipe/wordpress.php
-  - vendor/unleashedtech/deployer-recipes/config.yml
-  - vendor/unleashedtech/deployer-recipes/cms/wp/cache/flush.yml
-  - vendor/unleashedtech/deployer-recipes/cms/wp/rewrite/flush.yml
-  - vendor/unleashedtech/deployer-recipes/cms/wp/db/backup/create.php
-  - vendor/unleashedtech/deployer-recipes/db/backup/cleanup.yml
-  - vendor/unleashedtech/deployer-recipes/db/backup/download.php
-  - vendor/unleashedtech/deployer-recipes/cms/wp/db/backup/import.php
-  - vendor/unleashedtech/deployer-recipes/cms/wp/db/pull.yml
-  - vendor/unleashedtech/deployer-recipes/cms/wp/pre/deploy.yml
-  - vendor/unleashedtech/deployer-recipes/cms/wp/post/deploy.yml
-  - vendor/unleashedtech/deployer-recipes/cms/wp/pre/release.yml
-  - vendor/unleashedtech/deployer-recipes/cms/wp/uploads/pull.php
-  - vendor/unleashedtech/deployer-recipes/cms/wp/uploads/push.php
+    - recipe/common.php
+    - recipe/wordpress.php
+    - vendor/unleashedtech/deployer-recipes/config.yml
+    - vendor/unleashedtech/deployer-recipes/cms/wp/cache/flush.yml
+    - vendor/unleashedtech/deployer-recipes/cms/wp/rewrite/flush.yml
+    - vendor/unleashedtech/deployer-recipes/cms/wp/db/backup/create.php
+    - vendor/unleashedtech/deployer-recipes/db/backup/cleanup.yml
+    - vendor/unleashedtech/deployer-recipes/db/backup/download.php
+    - vendor/unleashedtech/deployer-recipes/cms/wp/db/backup/import.php
+    - vendor/unleashedtech/deployer-recipes/cms/wp/db/pull.yml
+    - vendor/unleashedtech/deployer-recipes/cms/wp/pre/deploy.yml
+    - vendor/unleashedtech/deployer-recipes/cms/wp/post/deploy.yml
+    - vendor/unleashedtech/deployer-recipes/cms/wp/pre/release.yml
+    - vendor/unleashedtech/deployer-recipes/cms/wp/uploads/pull.php
+    - vendor/unleashedtech/deployer-recipes/cms/wp/uploads/push.php
+    - vendor/unleashedtech/deployer-recipes/releases/cleanup.php
 
 config:
-  app_type: wordpress
-  upload_dir: 'web/app/uploads'
-  shared_files:
-    - .env
-  shared_dirs:
-    - '{{upload_dir}}'
-  writable_dirs:
-    - '{{upload_dir}}'
-  wp: '{{bin}}/wp'
+    app_type: wordpress
+    upload_dir: 'web/app/uploads'
+    shared_files:
+        - .env
+    shared_dirs:
+        - '{{upload_dir}}'
+    writable_dirs:
+        - '{{upload_dir}}'
+    wp: '{{bin}}/wp'
 
 tasks:
-  deploy:
-    - deploy:prepare
-    - cms:wp:pre:deploy
-    - cms:wp:pre:release
-    - deploy:symlink
-    - cms:wp:post:deploy
-    - deploy:cleanup
-    - deploy:unlock
+    deploy:
+        - deploy:prepare
+        - cms:wp:pre:deploy
+        - cms:wp:pre:release
+        - deploy:symlink
+        - cms:wp:post:deploy

--- a/cms/wp/5.yml
+++ b/cms/wp/5.yml
@@ -34,4 +34,5 @@ tasks:
     - cms:wp:pre:release
     - deploy:symlink
     - cms:wp:post:deploy
+    - deploy:cleanup
     - deploy:unlock

--- a/cms/wp/README.md
+++ b/cms/wp/README.md
@@ -19,7 +19,7 @@ being overridden.
 
 ```yaml
 import:
-    - "vendor/unleashedtech/deployer-recipes/cms/wp/5.yml"
+    - 'vendor/unleashedtech/deployer-recipes/cms/wp/5.yml'
 
 config:
     namespace: foo
@@ -31,4 +31,15 @@ config:
     upload_dir: 'docroot/app/uploads'
 ```
 
-Many defaults are provided. You will need to override a few of them.
+Many defaults are provided. You will need to override a few of them. Your configuration
+may be as simple as:
+
+```yaml
+import:
+    - 'vendor/unleashedtech/deployer-recipes/cms/wp/5.yml'
+
+config:
+    namespace: foo
+    repository_domain: 'repository1.example'
+    staging_domain: 'staging1.example'
+```

--- a/cms/wp/post/deploy.yml
+++ b/cms/wp/post/deploy.yml
@@ -1,7 +1,10 @@
 tasks:
-  cms:wp:post:deploy:
-    - cms:wp:cache:flush
-    - cms:wp:rewrite:flush
-    # if you need to create directories within the plugins directory then you also need to call this after the deploy
-    # because the deploy:vendors creates those directories anew (due to unzip of package).
-    - deploy:writable
+    cms:wp:post:deploy:
+        - cms:wp:cache:flush
+        - cms:wp:rewrite:flush
+        # if you need to create directories within the plugins directory then you also need to call this after the deploy
+        # because the deploy:vendors creates those directories anew (due to unzip of package).
+        - deploy:writable
+        - db:backup:cleanup
+        - releases:cleanup
+        - deploy:unlock

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "source": "https://github.com/unleashedtech/deployer-recipes"
     },
     "require": {
-        "php": "^7.2.5 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "deployer/deployer": "7.0.0-beta26"
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "deployer/deployer": "^7.0"
+        "deployer/deployer": "7.0.0-beta26"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/config.yml
+++ b/config.yml
@@ -7,11 +7,11 @@ config:
     app_directory_name: 'web'
     allow_anonymous_stats: false
     backups: '{{deploy_path}}/shared/backups'
+    backups_retention_days: 90
     bin: '{{release}}/vendor/bin'
     composer_install_options: '--verbose --prefer-dist --no-progress --no-interaction --no-dev --no-scripts --optimize-autoloader'
     deploy_root: '/srv/www'
     local_backups: 'backups'
-    keep_backups: 21
     local_database_backups: '{{local_backups}}/databases'
     local_file_backups: '{{local_backups}}/files'
     project: '{{app_type}}'

--- a/config.yml
+++ b/config.yml
@@ -7,7 +7,7 @@ config:
     app_directory_name: 'web'
     allow_anonymous_stats: false
     backups: '{{deploy_path}}/shared/backups'
-    backups_retention_days: 90
+    backups_limit: 21
     bin: '{{release}}/vendor/bin'
     composer_install_options: '--verbose --prefer-dist --no-progress --no-interaction --no-dev --no-scripts --optimize-autoloader'
     deploy_root: '/srv/www'

--- a/db/backup/cleanup.yml
+++ b/db/backup/cleanup.yml
@@ -1,6 +1,6 @@
 ---
 tasks:
-  db:backup:cleanup:
-    desc: "Clean up all the database backups older than {{backups_retention_days}} (defaults to 90)."
-    script:
-      - find {{backups}}* -mtime +{{backups_retention_days}} -exec rm {} \;
+    db:backup:cleanup:
+        desc: "Clean up all the database backups except the latest {{backups_limit}} files. (defaults to 21)"
+        script:
+            - ls -rt -1 {{backups}} | tail -n +{{backups_limit}} | xargs rm -fv

--- a/db/backup/cleanup.yml
+++ b/db/backup/cleanup.yml
@@ -1,6 +1,6 @@
 ---
 tasks:
   db:backup:cleanup:
-    desc: "Clean up all the database backups except the latest {{keep_backups}} files. (defaults to 21)"
+    desc: "Clean up all the database backups older than {{backups_retention_days}} (defaults to 90)."
     script:
-      - ls -rt -1 {{backups}} | tail -n +{{keep_backups}} | xargs rm -fv
+      - find {{backups}}* -mtime +{{backups_retention_days}} -exec rm {} \;

--- a/releases/cleanup.php
+++ b/releases/cleanup.php
@@ -10,11 +10,8 @@ declare(strict_types=1);
 
 namespace Deployer;
 
-// Use sudo in deploy:cleanup task for rm command.
-set('cleanup_use_sudo', false);
-
 desc('Clean up old releases');
-task('cms:drupal:release:cleanup', static function (): void {
+task('releases:cleanup', static function (): void {
     $releases = get('releases_list');
     $keep     = get('keep_releases');
     $sudo     = get('cleanup_use_sudo') ? 'sudo' : '';


### PR DESCRIPTION
- Fixes `cms:drupal:db:backup:create` database file name issue.
- Adds `deploy:cleanup` task call to WP & Drupal deploy recipes.
- Creates `backups_retention_days` variable.
- Revises `db:backup:cleanup` recipe to clean up based on `backups_retention_days` variable.
- Requires specific version of Deployer 7, for now.