### PR TITLE
Import fix

### DIFF
--- a/cms/drupal/db/backup/import.php
+++ b/cms/drupal/db/backup/import.php
@@ -17,7 +17,7 @@ use UnleashedTech\DeployerRecipes\VirtualMachine;
 
 task('cms:drupal:db:backup:import', static function (): void {
     $latestBackup = runLocally('ls -tr -1 {{local_database_backups}} | tail -1');
-    VirtualMachine::run('drush rq && drush sql-drop');
+    VirtualMachine::run('drush sql-drop -y');
     VirtualMachine::run('gunzip -c {{local_database_backups}}/' . $latestBackup . '| drush -r {{app_directory_name}} sql:cli');
     VirtualMachine::run('drush -r {{app_directory_name}} cr');
 })->desc('Import the latest database backup(s).')

--- a/cms/drupal/db/backup/import.php
+++ b/cms/drupal/db/backup/import.php
@@ -18,7 +18,7 @@ use UnleashedTech\DeployerRecipes\VirtualMachine;
 task('cms:drupal:db:backup:import', static function (): void {
     $latestBackup = runLocally('ls -tr -1 {{local_database_backups}} | tail -1');
     VirtualMachine::run('drush sql-drop -y');
-    VirtualMachine::run('gzip -dfq {{local_database_backups}}/' . $latestBackup );
+    runLocally('gzip -dfq {{local_database_backups}}/' . $latestBackup );
     $unzipped = VirtualMachine::run('ls -tr -1 {{local_database_backups}} | tail -1');
     /** SET commands that are exported (mysqldump) from some mysql environments
         (often those coming from master slave environments ) do not import

--- a/cms/drupal/db/backup/import.php
+++ b/cms/drupal/db/backup/import.php
@@ -19,7 +19,7 @@ task('cms:drupal:db:backup:import', static function (): void {
     $latestBackup = runLocally('ls -tr -1 {{local_database_backups}} | tail -1');
     VirtualMachine::run('drush sql-drop -y');
     runLocally('gzip -dfq {{local_database_backups}}/' . $latestBackup);
-    sleep(15); // Sleep 5seconds waiting for container sync to catch up.
+    sleep(10); // Sleep 10 seconds waiting for container sync to catch up.
     $unzipped = VirtualMachine::run('ls -tr -1 {{local_database_backups}} | tail -1');
     /** SET commands that are exported (mysqldump) from some mysql environments
         (often those coming from master slave environments ) do not import
@@ -32,7 +32,6 @@ task('cms:drupal:db:backup:import', static function (): void {
      *  It is harmless to strip these out for development purposes only.
      */
 
-    print $unzipped;
     VirtualMachine::run("perl -pi -e 's/SET @@.*//gd' {{local_database_backups}}/" . $unzipped);
     VirtualMachine::run('drush -v sql:cli < {{local_database_backups}}/' . $unzipped);
     VirtualMachine::run('drush cr');

--- a/cms/drupal/db/backup/import.php
+++ b/cms/drupal/db/backup/import.php
@@ -18,7 +18,21 @@ use UnleashedTech\DeployerRecipes\VirtualMachine;
 task('cms:drupal:db:backup:import', static function (): void {
     $latestBackup = runLocally('ls -tr -1 {{local_database_backups}} | tail -1');
     VirtualMachine::run('drush sql-drop -y');
-    VirtualMachine::run('gunzip -c {{local_database_backups}}/' . $latestBackup . '| drush sql:cli');
+    VirtualMachine::run('gunzip -c {{local_database_backups}}/' . $latestBackup );
+    $unzipped = runLocally('ls -tr -1 {{local_database_backups}} | tail -1');
+    /** SET commands that are exported (mysqldump) from some mysql environments
+        (often those coming from master slave environments ) do not import
+        on single mysql containers and throw this error:
+     *
+     *  > ERROR 1227 (42000) at line 18: Access denied; you need (at least one
+     *  of) the SUPER, SYSTEM_VARIABLES_ADMIN or SESSION_VARIABLES_ADMIN
+     *  privilege(s) for this operation
+     *
+     *  It is harmless to strip these out for development purposes only.
+     */
+
+    VirtualMachine::run("perl -pi -e 's/SET @@.*//gd' " . $unzipped);
+    VirtualMachine::run("drush -v sql:cli < " .$unzipped);
     VirtualMachine::run('drush cr');
 })->desc('Import the latest database backup(s).')
     ->once();

--- a/cms/drupal/db/backup/import.php
+++ b/cms/drupal/db/backup/import.php
@@ -19,7 +19,7 @@ task('cms:drupal:db:backup:import', static function (): void {
     $latestBackup = runLocally('ls -tr -1 {{local_database_backups}} | tail -1');
     VirtualMachine::run('drush sql-drop -y');
     VirtualMachine::run('gzip -dfq {{local_database_backups}}/' . $latestBackup );
-    $unzipped = runLocally('ls -tr -1 {{local_database_backups}} | tail -1');
+    $unzipped = VirtualMachine::run('ls -tr -1 {{local_database_backups}} | tail -1');
     /** SET commands that are exported (mysqldump) from some mysql environments
         (often those coming from master slave environments ) do not import
         on single mysql containers and throw this error:
@@ -31,7 +31,7 @@ task('cms:drupal:db:backup:import', static function (): void {
      *  It is harmless to strip these out for development purposes only.
      */
 
-    VirtualMachine::run("perl -pi -e 's/SET @@.*//gd' " . $unzipped);
+    VirtualMachine::run("perl -pi -e 's/SET @@.*//gd' {{local_database_backups}}/" . $unzipped);
     VirtualMachine::run("drush -v sql:cli < " .$unzipped);
     VirtualMachine::run('drush cr');
 })->desc('Import the latest database backup(s).')

--- a/cms/drupal/db/backup/import.php
+++ b/cms/drupal/db/backup/import.php
@@ -32,7 +32,7 @@ task('cms:drupal:db:backup:import', static function (): void {
      */
 
     VirtualMachine::run("perl -pi -e 's/SET @@.*//gd' {{local_database_backups}}/" . $unzipped);
-    VirtualMachine::run("drush -v sql:cli < " .$unzipped);
+    VirtualMachine::run("drush -v sql:cli < {{local_database_backups}}/" .$unzipped);
     VirtualMachine::run('drush cr');
 })->desc('Import the latest database backup(s).')
     ->once();

--- a/cms/drupal/db/backup/import.php
+++ b/cms/drupal/db/backup/import.php
@@ -19,6 +19,7 @@ task('cms:drupal:db:backup:import', static function (): void {
     $latestBackup = runLocally('ls -tr -1 {{local_database_backups}} | tail -1');
     VirtualMachine::run('drush sql-drop -y');
     runLocally('gzip -dfq {{local_database_backups}}/' . $latestBackup );
+    sleep(5); // Sleep 5seconds waiting for container sync to catch up.
     $unzipped = VirtualMachine::run('ls -tr -1 {{local_database_backups}} | tail -1');
     /** SET commands that are exported (mysqldump) from some mysql environments
         (often those coming from master slave environments ) do not import

--- a/cms/drupal/db/backup/import.php
+++ b/cms/drupal/db/backup/import.php
@@ -19,7 +19,7 @@ task('cms:drupal:db:backup:import', static function (): void {
     $latestBackup = runLocally('ls -tr -1 {{local_database_backups}} | tail -1');
     VirtualMachine::run('drush sql-drop -y');
     runLocally('gzip -dfq {{local_database_backups}}/' . $latestBackup);
-    sleep(10); // Sleep 10 seconds waiting for container sync to catch up.
+    \sleep(10); // Sleep 10 seconds waiting for container sync to catch up.
     $unzipped = VirtualMachine::run('ls -tr -1 {{local_database_backups}} | tail -1');
     /** SET commands that are exported (mysqldump) from some mysql environments
         (often those coming from master slave environments ) do not import

--- a/cms/drupal/db/backup/import.php
+++ b/cms/drupal/db/backup/import.php
@@ -18,8 +18,8 @@ use UnleashedTech\DeployerRecipes\VirtualMachine;
 task('cms:drupal:db:backup:import', static function (): void {
     $latestBackup = runLocally('ls -tr -1 {{local_database_backups}} | tail -1');
     VirtualMachine::run('drush sql-drop -y');
-    runLocally('gzip -dfq {{local_database_backups}}/' . $latestBackup );
-    sleep(5); // Sleep 5seconds waiting for container sync to catch up.
+    runLocally('gzip -dfq {{local_database_backups}}/' . $latestBackup);
+    sleep(15); // Sleep 5seconds waiting for container sync to catch up.
     $unzipped = VirtualMachine::run('ls -tr -1 {{local_database_backups}} | tail -1');
     /** SET commands that are exported (mysqldump) from some mysql environments
         (often those coming from master slave environments ) do not import
@@ -32,8 +32,9 @@ task('cms:drupal:db:backup:import', static function (): void {
      *  It is harmless to strip these out for development purposes only.
      */
 
+    print $unzipped;
     VirtualMachine::run("perl -pi -e 's/SET @@.*//gd' {{local_database_backups}}/" . $unzipped);
-    VirtualMachine::run("drush -v sql:cli < {{local_database_backups}}/" .$unzipped);
+    VirtualMachine::run('drush -v sql:cli < {{local_database_backups}}/' . $unzipped);
     VirtualMachine::run('drush cr');
 })->desc('Import the latest database backup(s).')
     ->once();

--- a/cms/drupal/db/backup/import.php
+++ b/cms/drupal/db/backup/import.php
@@ -18,7 +18,7 @@ use UnleashedTech\DeployerRecipes\VirtualMachine;
 task('cms:drupal:db:backup:import', static function (): void {
     $latestBackup = runLocally('ls -tr -1 {{local_database_backups}} | tail -1');
     VirtualMachine::run('drush sql-drop -y');
-    VirtualMachine::run('gunzip -c {{local_database_backups}}/' . $latestBackup . '| drush -r {{app_directory_name}} sql:cli');
-    VirtualMachine::run('drush -r {{app_directory_name}} cr');
+    VirtualMachine::run('gunzip -c {{local_database_backups}}/' . $latestBackup . '| drush sql:cli');
+    VirtualMachine::run('drush cr');
 })->desc('Import the latest database backup(s).')
     ->once();

--- a/cms/drupal/db/backup/import.php
+++ b/cms/drupal/db/backup/import.php
@@ -18,7 +18,7 @@ use UnleashedTech\DeployerRecipes\VirtualMachine;
 task('cms:drupal:db:backup:import', static function (): void {
     $latestBackup = runLocally('ls -tr -1 {{local_database_backups}} | tail -1');
     VirtualMachine::run('drush sql-drop -y');
-    VirtualMachine::run('gunzip -c {{local_database_backups}}/' . $latestBackup );
+    VirtualMachine::run('gzip -dfq {{local_database_backups}}/' . $latestBackup );
     $unzipped = runLocally('ls -tr -1 {{local_database_backups}} | tail -1');
     /** SET commands that are exported (mysqldump) from some mysql environments
         (often those coming from master slave environments ) do not import

--- a/cms/drupal/db/backup/import.php
+++ b/cms/drupal/db/backup/import.php
@@ -17,7 +17,7 @@ use UnleashedTech\DeployerRecipes\VirtualMachine;
 
 task('cms:drupal:db:backup:import', static function (): void {
     $latestBackup = runLocally('ls -tr -1 {{local_database_backups}} | tail -1');
-    VirtualMachine::run('drush -r {{app_directory_name}} rq && drush sql-drop');
+    VirtualMachine::run('drush rq && drush sql-drop');
     VirtualMachine::run('gunzip -c {{local_database_backups}}/' . $latestBackup . '| drush -r {{app_directory_name}} sql:cli');
     VirtualMachine::run('drush -r {{app_directory_name}} cr');
 })->desc('Import the latest database backup(s).')

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": "^7.3 || ^8.0",
-        "deployer/dist": "7.0.0-rc.3"
+        "deployer/dist": "7.0.0-rc.4"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/VirtualMachine.php
+++ b/src/VirtualMachine.php
@@ -14,16 +14,18 @@ use function Deployer\runLocally;
  */
 class VirtualMachine
 {
-    public static function run(string $command): void
+    public static function run(string $command): string
     {
+        $returnValue = '';
         if (\is_file('.ddev/config.yaml')) {
-            runLocally(\sprintf('ddev exec "%s"', $command));
+            $returnValue = runLocally(\sprintf('ddev exec "%s"', $command));
         } elseif (\is_file('.docksal/docksal.yml')) {
-            runLocally(\sprintf('fin exec "%s"', $command));
+            $returnValue = runLocally(\sprintf('fin exec "%s"', $command));
         } elseif (\is_file('Vagrantfile')) {
-            runLocally(\sprintf('vagrant ssh -c "%s"', $command));
+            $returnValue = runLocally(\sprintf('vagrant ssh -c "%s"', $command));
         } else {
             throw new \UnexpectedValueException('Unsupported VM.');
         }
+        return $returnValue;
     }
 }


### PR DESCRIPTION
If mysql source (production in this case) has SET statements in the db export file then a simple perl regex strips them out.

SET sql statements are often injected into db exports when mysql is setup as master slave.  Code also has comments explaining.

UT Internal ticket reference: 26806307

It is also nice to get values back from the run function as does the runLocally function. So a string value was added as the return value.

And finally a new version of deployer is specified.