### PR TITLE
Magento2 shared

### DIFF
--- a/cms/magento/magento2.php
+++ b/cms/magento/magento2.php
@@ -23,7 +23,6 @@ fill('shared_dirs', [
     'pub/page-cache',
     'pub/sitemap',
     'pub/static',
-    'generated',
 ]);
 fill('shared_files', [
     'app/etc/env.php',

--- a/cms/magento/magento2.php
+++ b/cms/magento/magento2.php
@@ -18,7 +18,16 @@ import('recipe/common.php');
 set('app_type', 'magento');
 set('mage', 'bin/magento');
 fill('shared_dirs', [
-    'var',
+    'var/composer_home',
+    'var/log',
+    'var/export',
+    'var/report',
+    'var/import',
+    'var/import_history',
+    'var/session',
+    'var/importexport',
+    'var/backups',
+    'var/tmp',
     'pub/media',
     'pub/page-cache',
     'pub/sitemap',


### PR DESCRIPTION
This addresses but doesn't entirely fix all the permission issues.  

As seen in the community recipe https://github.com/deployphp/deployer/blob/aec3b51ecb83893f973cd4628513beb344cc93cd/recipe/magento2.php#L45

They explicitly list out var and it's subdirs in the shared_dirs array.   Deployer by default does a `rm -rf` on all those directories AND then does a `mkdir -p` on those same directories.  If we remove all the subdirs in the name of efficiency then the subdirs get removed and NOT recreated.  If we leave our recipe without the subdirs then Magento may or may not automatically , at run time, detect a missing directory and create it, but not in our experience.


