### PR TITLE
Adding documentation and code comments justifying the UT "Way"

### DIFF
--- a/cms/magento/README.md
+++ b/cms/magento/README.md
@@ -27,3 +27,33 @@ import:
 ```
 
 [Magento2 Deployment Strategies and Discussions](https://magento.stackexchange.com/questions/315786/magento-2-configuration-settings-clarify-appconfigdump-vs-appconfigimport)
+
+
+## NOTES on Linux File Permissions
+
+In order for the linux deployer user (whom is probably a different user than the www-data nginx user) you will need to have the following ownership
+and setguid bits set on the destination servers.
+
+##### This is a one time setup so that all shared files are owned by Nginx and all future created subdirs
+
+    ```bash
+    sudo chown -R www-data:www-data /srv/www/{{your deploy project name}}/shared/docroot
+    chmod g+s /srv/www/{{your deploy project name}}/shared/docroot
+    chmod g+s /srv/www/{{your deploy project name}}/shared/docroot/*
+    ```
+##### One time Setup so all releases are owned by Nginx and all future created subdirs
+
+    ```bash
+    sudo chown www-data:www-data /srv/www/{{your deploy project name}}/releases
+    chmod g+s /srv/www/{{your deploy project name}}/releases
+    ```
+
+##### These files are owned by www-data from above command
+##### this needs to be writable by deployer who is a part of the www-data group.
+
+    ```bash
+    chmod 664 /srv/www/{{your deploy project name}}/shared/docroot/app/etc/env.php
+    chmod 664 /srv/www/{{your deploy project name}}/shared/docroot/app/etc/config.php
+    ```
+
+

--- a/cms/magento/magento2.php
+++ b/cms/magento/magento2.php
@@ -17,6 +17,8 @@ import('recipe/common.php');
 
 set('app_type', 'magento');
 set('mage', 'bin/magento');
+
+// Please see notes in the magento README regarding the permissions for the parents of these files.
 fill('shared_dirs', [
     'var/composer_home',
     'var/log',
@@ -33,10 +35,17 @@ fill('shared_dirs', [
     'pub/sitemap',
     'pub/static',
 ]);
+
+// Please see notes in the magento README regarding the permissions for this file.
 fill('shared_files', [
     'app/etc/env.php',
 ]);
+
+// Please see notes in the magento README regarding the permissions for the directories that are writable
+// At UT we believe the deployer user should not be running chown for each deploy.
 fill('writable_dirs', []);
+
+// Please see notes in the magento README regarding the permissions for the directories that are writable
 fill('clear_paths', [
     'generated/*',
     'pub/static/_cache/*',


### PR DESCRIPTION
We believe the deployer linux user should not be running chown or chmod on every deploy and thus have an empty "writable_dirs" variable.  This however forces us to set some very explicit permissions on the parent directories.