### PR TITLE
Remove deployer/dist composer deprecation warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require": {
         "php": "^7.3 || ^8.0",
-        "deployer/dist": "7.0.0-rc.4"
+        "deployer/deployer": "^7"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -51,7 +51,6 @@
         }
     },
     "require-dev": {
-        "deployer/deployer": "7.0.0-rc.4",
         "roave/security-advisories": "dev-latest",
         "unleashedtech/php-coding-standard": "^3.1"
     }


### PR DESCRIPTION

The deployer/dist install method is deprecated now.  This switches to using the recommendation of deployer/deployer.
